### PR TITLE
Fix the command in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ COPY --from=builder-go /app/client/dist ./client/dist
 
 EXPOSE 9595
 
-CMD ["./client"]
+CMD ["./console"]


### PR DESCRIPTION
# Desciption

The PR fixes the command in the dockerfile

# Problem

Running docker `docker run -p 9595:9595 console` as specified in the readme throws an error.